### PR TITLE
FIX: parse urls to push url-specific data

### DIFF
--- a/app.py
+++ b/app.py
@@ -239,7 +239,7 @@ class DomainScanStack(core.Stack):
         ##################################
         
         db = dynamodb.Table(
-            self, "fed-a11y-db",
+            self, "fed-a11y-scan-db",
             partition_key=dynamodb.Attribute(
                 name="agency+org+domain+subdomain+path",
                 type=dynamodb.AttributeType.STRING

--- a/tests/test_site_mapper.py
+++ b/tests/test_site_mapper.py
@@ -1,5 +1,6 @@
 import boto3
 
+import pytest
 from tests.fixtures import *
 
 
@@ -23,3 +24,20 @@ def test_send_message(sqs):
     
     r = send_message({"Id": "1", "MessageBody": "foo"})
     assert "Successful" in r.keys()
+
+
+@pytest.mark.parametrize("url, expected", [
+    ('https://www.foo.gov', ('foo', '', '')),
+    ('https://www.bar.foo.gov', ('foo', 'bar', '')),
+    ('https://www.fiz.bar.foo.gov', ('foo', 'fiz.bar', '')),
+    ('https://www.foo.gov/baz', ('foo', '', 'baz')),
+    ('https://www.foo.gov/baz/biz', ('foo', '', 'baz/biz') ),
+    ('https://www.bar.foo.gov/baz/biz', ('foo', 'bar', 'baz/biz') ),
+    ('https://www.fiz.foo.gov/bar', ('foo', 'fiz', 'bar')),
+    ('https://foo.gov', ('foo', '', '')),
+    ('https://bar.foo.gov', ('foo', 'bar', ''))
+])
+def test_format_url(url, expected):
+    from lambdas.site_mapper.handler import MySpider
+    result = MySpider.format_url(url)
+    assert result == expected

--- a/tests/test_site_mapper.py
+++ b/tests/test_site_mapper.py
@@ -31,8 +31,8 @@ def test_send_message(sqs):
     ('https://www.bar.foo.gov', ('foo', 'bar', '')),
     ('https://www.fiz.bar.foo.gov', ('foo', 'fiz.bar', '')),
     ('https://www.foo.gov/baz', ('foo', '', 'baz')),
-    ('https://www.foo.gov/baz/biz', ('foo', '', 'baz/biz') ),
-    ('https://www.bar.foo.gov/baz/biz', ('foo', 'bar', 'baz/biz') ),
+    ('https://www.foo.gov/baz/biz', ('foo', '', 'baz/biz')),
+    ('https://www.bar.foo.gov/baz/biz', ('foo', 'bar', 'baz/biz')),
     ('https://www.fiz.foo.gov/bar', ('foo', 'fiz', 'bar')),
     ('https://foo.gov', ('foo', '', '')),
     ('https://bar.foo.gov', ('foo', 'bar', ''))


### PR DESCRIPTION
Previously, the spider was pushing urls with metadata that belonged to the start_url of the spider instead of the urls found during crawling. This fixes that.